### PR TITLE
bump the mpt circuit which revert a breaking change in circuit

### DIFF
--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 eth-types = { git = "https://github.com/scroll-tech/zkevm-circuits.git", branch = "scroll-dev-0714-opt" }
-mpt-circuits = { package = "halo2-mpt-circuits", git = "https://github.com/scroll-tech/mpt-circuit.git", rev = "5761b8d9382b8865348ae3d4bafd453e0a227808" }
+mpt-circuits = { package = "halo2-mpt-circuits", git = "https://github.com/scroll-tech/mpt-circuit.git", rev = "3e86c43a90e2a64962e65dd3f8e31b5d6ec7055f" }
 base64 = "0.13.0"
 blake2 = "0.10.3"
 ethers-core = "0.6.0"

--- a/zkevm/Cargo.toml
+++ b/zkevm/Cargo.toml
@@ -18,7 +18,7 @@ halo2_proofs = { git = "https://github.com/scroll-tech/halo2.git", branch = "scr
 bus-mapping = { git = "https://github.com/scroll-tech/zkevm-circuits.git", branch = "scroll-dev-0714-opt" }
 eth-types = { git = "https://github.com/scroll-tech/zkevm-circuits.git", branch = "scroll-dev-0714-opt" }
 zkevm-circuits = { git = "https://github.com/scroll-tech/zkevm-circuits.git", branch = "scroll-dev-0714-opt", features = ["test"] }
-mpt-circuits = { package = "halo2-mpt-circuits", git = "https://github.com/scroll-tech/mpt-circuit.git", rev = "5761b8d9382b8865348ae3d4bafd453e0a227808" }
+mpt-circuits = { package = "halo2-mpt-circuits", git = "https://github.com/scroll-tech/mpt-circuit.git", rev = "3e86c43a90e2a64962e65dd3f8e31b5d6ec7055f" }
 rand = "0.8"
 rand_xorshift = "0.3"
 is-even = "1.0.0"


### PR DESCRIPTION
PR 42 has bump the depended mpt-circuit to a version with breaking changes in circuit,  which is a temporary fixing for encoiunting the witness with selfdestruct.

Now we decide to revert this updating in circuit to avoid impacts on integration tests.