### PR TITLE
Make poseidon codehash work temporarily

### DIFF
--- a/types/src/eth.rs
+++ b/types/src/eth.rs
@@ -154,6 +154,8 @@ pub struct ExecutionResult {
     pub return_value: String,
     pub from: Option<AccountProofWrapper>,
     pub to: Option<AccountProofWrapper>,
+    #[serde(rename = "accountAfter", default)]
+    pub account_after: Vec<AccountProofWrapper>,
     #[serde(rename = "accountCreated")]
     pub account_created: Option<AccountProofWrapper>,
     #[serde(rename = "codeHash")]

--- a/zkevm/src/circuit/builder.rs
+++ b/zkevm/src/circuit/builder.rs
@@ -203,6 +203,7 @@ pub fn build_statedb_and_codedb(block: &BlockResult) -> Result<(StateDB, CodeDB)
                 acc_mut.code_hash = acc.data.code_hash;
                 acc_mut.balance = acc.data.balance;
             } else {
+                // TODO(@noel2004): please complete the comment below.
                 // only
                 sdb.set_account(
                     addr,
@@ -272,11 +273,8 @@ pub fn build_statedb_and_codedb(block: &BlockResult) -> Result<(StateDB, CodeDB)
                         // TODO: need to insert code to codedb with poseidon codehash
                         // if the call is persistent
                     }
-                    //OpcodeId::CODESIZE
-                    //| OpcodeId::CODECOPY
                     OpcodeId::EXTCODESIZE | OpcodeId::EXTCODECOPY => {
                         let code = data.get_code_at(0);
-                        //trace_code(&mut cdb, code)
                         trace_code(&mut cdb, step, &sdb, code, 0).unwrap_or_else(|err| {
                             log::error!("temporarily skip error in EXTCODE op: {}", err);
                         });

--- a/zkevm/src/circuit/builder.rs
+++ b/zkevm/src/circuit/builder.rs
@@ -268,7 +268,10 @@ pub fn build_statedb_and_codedb(block: &BlockResult) -> Result<(StateDB, CodeDB)
                         let callee_code = data.get_code_at(1);
                         trace_code(&mut cdb, step, &sdb, callee_code, 1)?;
                     }
-                    OpcodeId::CREATE | OpcodeId::CREATE2 => {}
+                    OpcodeId::CREATE | OpcodeId::CREATE2 => {
+                        // TODO: need to insert code to codedb with poseidon codehash
+                        // if the call is persistent
+                    }
                     //OpcodeId::CODESIZE
                     //| OpcodeId::CODECOPY
                     OpcodeId::EXTCODESIZE | OpcodeId::EXTCODECOPY => {

--- a/zkevm/src/circuit/builder.rs
+++ b/zkevm/src/circuit/builder.rs
@@ -1,6 +1,7 @@
 use bus_mapping::circuit_input_builder::{Block as cBlock, CircuitInputBuilder};
 
 use bus_mapping::state_db::{Account, CodeDB, StateDB};
+use eth_types::ToAddress;
 use eth_types::{evm_types::OpcodeId, Field};
 use ethers_core::types::{Address, Bytes};
 
@@ -11,7 +12,7 @@ use is_even::IsEven;
 use super::mpt;
 use std::collections::HashMap;
 use strum::IntoEnumIterator;
-use types::eth::BlockResult;
+use types::eth::{ExecutionResult, ExecStep, BlockResult};
 use zkevm_circuits::evm_circuit::table::FixedTableTag;
 
 use halo2_proofs::arithmetic::{BaseExt, FieldExt};
@@ -19,6 +20,7 @@ use mpt_circuits::hash::Hashable;
 use zkevm_circuits::evm_circuit::witness::{block_convert, Block};
 
 use super::DEGREE;
+use anyhow::anyhow;
 
 fn verify_proof_leaf<T: Default>(inp: mpt::TrieProof<T>, key_buf: &[u8; 32]) -> mpt::TrieProof<T> {
     let first_16bytes: [u8; 16] = key_buf[..16].try_into().expect("expect first 16 bytes");
@@ -95,18 +97,50 @@ pub fn decode_bytecode(bytecode: &str) -> Result<Vec<u8>, anyhow::Error> {
     hex::decode(stripped).map_err(|e| e.into())
 }
 
-pub fn build_statedb_and_codedb(block: &BlockResult) -> Result<(StateDB, CodeDB), anyhow::Error> {
-    let mut sdb = StateDB::new();
-    let mut cdb = CodeDB::new();
-
-    cdb.insert(decode_bytecode(EMPTY_ACCOUNT_CODE)?);
-
-    for execution_result in &block.execution_results {
-        if let Some(bytecode) = execution_result.byte_code.clone() {
-            cdb.insert(decode_bytecode(&bytecode)?);
+fn get_account_deployed_codehash(execution_result : &ExecutionResult) -> Result<eth_types::H256, anyhow::Error> {
+    let created_acc = execution_result.account_created.as_ref().expect("called when field existed").address.as_ref().unwrap();
+    for state in &execution_result.account_after {
+        if Some(created_acc) == state.address.as_ref() {
+            return state.code_hash.ok_or_else(||anyhow!("empty code hash"));
         }
     }
 
+    Err(anyhow!("can not find created address in account after"))
+}
+
+fn get_account_created_codehash(step : &ExecStep) -> Result<eth_types::H256, anyhow::Error> {
+
+    let extra_data = step.extra_data.as_ref().ok_or_else(||anyhow!("no extra data in create context"))?;
+
+    let proof_list = extra_data.proof_list.as_ref().expect("should has proof list");
+
+    if proof_list.len() < 2 {
+        Err(anyhow!("wrong fields in create context"))
+    }else {
+        proof_list[1].code_hash.ok_or_else(||anyhow!("empty code hash in final state"))
+    }
+}
+
+fn trace_code(cdb: &mut CodeDB, step: &ExecStep, sdb: &StateDB, code: Bytes) -> Result<(), anyhow::Error>{
+    let stack = step.stack.as_ref().expect("should have stack in call context");
+    let addr = stack[stack.len()-2].to_address(); //stack N-1 
+
+    let (existed, data) = sdb.get_account(&addr);
+    if !existed {
+        return Err(anyhow!("missed account data for {}", addr));
+    }
+
+    cdb.0.insert(data.code_hash, code.to_vec());
+    Ok(())
+}
+
+pub fn build_statedb_and_codedb(
+    block: &BlockResult,
+) -> Result<(StateDB, CodeDB), anyhow::Error> {
+    let mut sdb = StateDB::new();
+    let mut cdb = CodeDB::new();
+
+    // step1: insert proof into statedb
     let storage_trace = &block.storage_trace;
     if let Some(acc_proofs) = &storage_trace.proofs {
         for (addr, acc) in acc_proofs.iter() {
@@ -114,16 +148,10 @@ pub fn build_statedb_and_codedb(block: &BlockResult) -> Result<(StateDB, CodeDB)
             let acc = verify_proof_leaf(acc_proof, &extend_address_to_h256(addr));
             if acc.key.is_some() {
                 // a valid leaf
-                sdb.set_account(
-                    addr,
-                    Account {
-                        nonce: acc.data.nonce.into(),
-                        balance: acc.data.balance,
-                        storage: HashMap::new(),
-                        code_hash: acc.data.code_hash,
-                    },
-                );
-            //                log::info!("set account {:?}, {:?}", addr, acc.data);
+                let (_, acc_mut) = sdb.get_account_mut(addr);
+                acc_mut.nonce = acc.data.nonce.into();
+                acc_mut.code_hash = acc.data.code_hash;
+                acc_mut.balance = acc.data.balance;
             } else {
                 // only
                 sdb.set_account(
@@ -135,7 +163,6 @@ pub fn build_statedb_and_codedb(block: &BlockResult) -> Result<(StateDB, CodeDB)
                         code_hash: Default::default(),
                     },
                 );
-                //                log::info!("set empty account {:?}", addr);
             }
         }
     }
@@ -165,52 +192,48 @@ pub fn build_statedb_and_codedb(block: &BlockResult) -> Result<(StateDB, CodeDB)
         }
     }
 
-    for er in block.execution_results.iter().rev() {
-        for step in er.exec_steps.iter().rev() {
+    // step2: insert code into codedb
+    // notice empty codehash always kept as keccak256(nil)
+    cdb.insert(decode_bytecode(EMPTY_ACCOUNT_CODE)?);
+
+    for execution_result in &block.execution_results {
+        if let Some(bytecode) = &execution_result.byte_code {
+            if execution_result.account_created.is_some() {
+                let code_hash = get_account_deployed_codehash(execution_result)?;
+                cdb.0.insert(code_hash, decode_bytecode(bytecode)?.to_vec());
+            }else {
+                cdb.0.insert(execution_result.code_hash.ok_or_else(||anyhow!("empty code hash in result"))?, decode_bytecode(bytecode)?.to_vec());
+            }
+        }
+
+        for step in execution_result.exec_steps.iter().rev() {
             if let Some(data) = &step.extra_data {
                 match step.op {
                     OpcodeId::CALL | OpcodeId::CALLCODE => {
-                        let caller_code = data.get_code_at(0);
+                        //let caller_code = data.get_code_at(0);
                         let callee_code = data.get_code_at(1);
-                        trace_code(&mut cdb, caller_code);
-                        trace_code(&mut cdb, callee_code);
+                        //trace_code(&mut cdb, step, &sdb, caller_code);
+                        trace_code(&mut cdb, step, &sdb, callee_code)?;
                     }
 
                     OpcodeId::DELEGATECALL | OpcodeId::STATICCALL => {
-                        let caller_code = data.get_code_at(0);
+                        //let caller_code = data.get_code_at(0);
                         let callee_code = data.get_code_at(1);
-                        trace_code(&mut cdb, caller_code);
-                        trace_code(&mut cdb, callee_code);
+                        //trace_code(&mut cdb, caller_code);
+                        trace_code(&mut cdb, step, &sdb, callee_code)?;
                     }
 
                     OpcodeId::CREATE | OpcodeId::CREATE2 => {
                         let created_code = data.get_code_at(0);
-                        trace_code(&mut cdb, created_code);
+                        let code_hash = get_account_created_codehash(step)?;
+                        cdb.0.insert(code_hash, created_code.to_vec());
                     }
-                    /*
-                                        OpcodeId::SLOAD | OpcodeId::SSTORE | OpcodeId::SELFBALANCE => {
-                                            let contract_proof = data.get_proof_at(0);
-                                            trace_proof(&mut sdb, contract_proof)
-                                        }
-
-                                        OpcodeId::SELFDESTRUCT => {
-                                            let caller_proof = data.get_proof_at(0);
-                                            let callee_proof = data.get_proof_at(1);
-                                            trace_proof(&mut sdb, caller_proof);
-                                            trace_proof(&mut sdb, callee_proof);
-                                        }
-
-                                        OpcodeId::EXTCODEHASH | OpcodeId::BALANCE => {
-                                            let proof = data.get_proof_at(0);
-                                            trace_proof(&mut sdb, proof)
-                                        }
-                    */
                     OpcodeId::CODESIZE
                     | OpcodeId::CODECOPY
                     | OpcodeId::EXTCODESIZE
                     | OpcodeId::EXTCODECOPY => {
-                        let code = data.get_code_at(0);
-                        trace_code(&mut cdb, code)
+                        //let code = data.get_code_at(0);
+                        //trace_code(&mut cdb, code)
                     }
 
                     _ => {}
@@ -241,9 +264,6 @@ pub fn build_statedb_and_codedb(block: &BlockResult) -> Result<(StateDB, CodeDB)
     Ok((sdb, cdb))
 }
 
-pub fn trace_code(cdb: &mut CodeDB, code: Bytes) {
-    cdb.insert(code.to_vec());
-}
 /*
 pub fn trace_proof(sdb: &mut StateDB, proof: Option<AccountProofWrapper>) {
     // `to` may be empty

--- a/zkevm/src/circuit/builder.rs
+++ b/zkevm/src/circuit/builder.rs
@@ -87,8 +87,7 @@ pub fn block_result_to_witness_block<F: Field>(
                 .map(|call| call.code_hash)
                 .into_iter()
                 .map(|code_hash| {
-                    let code_hash_u = U256::from_big_endian(code_hash.as_bytes());
-                    let bytecode = Bytecode::new(
+                    let mut bytecode = Bytecode::new(
                         builder
                             .code_db
                             .0
@@ -96,7 +95,8 @@ pub fn block_result_to_witness_block<F: Field>(
                             .cloned()
                             .expect("code db should has contain the code"),
                     );
-                    (code_hash_u, bytecode)
+                    bytecode.hash = U256::from_big_endian(code_hash.as_bytes());
+                    (bytecode.hash, bytecode)
                 })
         })
         .collect();

--- a/zkevm/src/circuit/builder.rs
+++ b/zkevm/src/circuit/builder.rs
@@ -12,7 +12,7 @@ use is_even::IsEven;
 use super::mpt;
 use std::collections::HashMap;
 use strum::IntoEnumIterator;
-use types::eth::{BlockResult, ExecStep, ExecutionResult};
+use types::eth::{BlockResult, ExecStep};
 use zkevm_circuits::evm_circuit::table::FixedTableTag;
 
 use halo2_proofs::arithmetic::{BaseExt, FieldExt};
@@ -121,7 +121,7 @@ pub fn decode_bytecode(bytecode: &str) -> Result<Vec<u8>, anyhow::Error> {
 
     hex::decode(stripped).map_err(|e| e.into())
 }
-/* 
+/*
 fn get_account_deployed_codehash(
     execution_result: &ExecutionResult,
 ) -> Result<eth_types::H256, anyhow::Error> {
@@ -177,7 +177,7 @@ fn trace_code(
     let (existed, data) = sdb.get_account(&addr);
     if !existed {
         // we may call non-contract or non-exist address
-        return if code.as_ref().len() == 0 {
+        return if code.as_ref().is_empty() {
             Ok(())
         } else {
             Err(anyhow!("missed account data for {}", addr))
@@ -257,7 +257,7 @@ pub fn build_statedb_and_codedb(block: &BlockResult) -> Result<(StateDB, CodeDB)
                         .ok_or_else(|| anyhow!("empty code hash in result"))?,
                     decode_bytecode(bytecode)?.to_vec(),
                 );
-            } 
+            }
         }
 
         for step in execution_result.exec_steps.iter().rev() {
@@ -277,15 +277,13 @@ pub fn build_statedb_and_codedb(block: &BlockResult) -> Result<(StateDB, CodeDB)
                         trace_code(&mut cdb, step, &sdb, callee_code, 1)?;
                     }
 
-                    OpcodeId::CREATE | OpcodeId::CREATE2 => {
-                    }
+                    OpcodeId::CREATE | OpcodeId::CREATE2 => {}
                     //OpcodeId::CODESIZE
                     //| OpcodeId::CODECOPY
-                    OpcodeId::EXTCODESIZE
-                    | OpcodeId::EXTCODECOPY => {
+                    OpcodeId::EXTCODESIZE | OpcodeId::EXTCODECOPY => {
                         let code = data.get_code_at(0);
                         //trace_code(&mut cdb, code)
-                        trace_code(&mut cdb, step, &sdb, code, 0).unwrap_or_else(|err|{
+                        trace_code(&mut cdb, step, &sdb, code, 0).unwrap_or_else(|err| {
                             log::error!("temporarily skip error in EXTCODE op: {}", err);
                         });
                     }


### PR DESCRIPTION
The base idea is pick codehash directly from trace rather than calculate it from codebytes, and build a correct code_db for witness generation:

1. For any call op, we pick codehash from sdb (we suppose the codehash never changed after contract is deployed)
2. For create, we can only pick codehash if the creation is success. However, we should notice that it is not need to put the code in db if deployment has failed (no one would call it again later)
3. For `EXTCODESIZE`, we has no way to get the codehash now. we need some update in l2geth to add the target account also being traced in `storageTrace` field. And we found that it is not need to update codeDB with codes in `EXTCODE` op

> ~However, evm circuit do not always respect the codehash provided from code_db, instead in `block_convert` it calculate codehash from codebytes directly. Even we had hacked this behavior, we still encounter wrong constraint because the circuit may still use a calculated codehash somewhere rather than respect the key in `bytecodes` table in block witness.~

Now we are partially done with following hacks to the witness block:

1. We notice we do not need to insert codebyte into codeDB for any code being created in tx; ~however, we should update the `Call` data's `code_hash` field after the bus-mapping block has been build, (still working: circuit can be assigned but encounter 'The constraint system is not satisfied' error)~ though the codehash generated in bus-mapping is inconsistent with the correct value, circuit could still pass unless the account being created would be used in another tx with the same block (which maybe rare case)

2. We update `bytecodes` table in the finally witness block, with this change the block `0x8bdbc94de271c889d5052af5f4c3816f80634d265bfa5a353f223694a9b8e201` has been provided successfully


