### PR TITLE
fix: use docker image `rust-builder` with tag `nightly-2022-08-23` in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build common-rs
-FROM scrolltech/rust-builder as builder
+FROM scrolltech/rust-builder:nightly-2022-08-23 as builder
 
 RUN mkdir -p /root/src
 ADD . /root/src


### PR DESCRIPTION
Related `devops` issue - https://github.com/scroll-tech/devops/pull/18